### PR TITLE
Added buttons and a universal styling set

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -94,37 +94,57 @@ nav ul li a:hover {
   margin: 5px 0;
 }
 
-.set-btn {
-  background-color: var(--main-color-light-green);
+/********** Decided to have a universal set of buttons based on their action **********/
+.primary-btn,
+.secondary-btn,
+.danger-btn {
   padding: 10px 20px;
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  margin: 1em;
+  margin: 1em 0.25em 1em 1em;
   font-size: 1em;
+  width: 175px;
+  height: 2.5em;
 }
 
-.set-btn a {
+.primary-btn {
+  background-color: var(--main-color-light-green);
+}
+
+.secondary-btn,
+.add-btn {
+  background-color: var(--main-color-white);
+}
+
+.danger-btn {
+  background-color: red;
+}
+
+.primary-btn a,
+.danger-btn a {
   color: var(--main-color-white);
   text-decoration: none;
 }
 
+.secondary-btn a {
+  color: var(--main-color-light-green);
+  text-decoration: none;
+}
+
+/********** Custom styled buttons **********/
+.custom-btn {
+  margin: 1em 0 1em 0;
+}
+
 .add-btn {
-  background-color: var(--main-color-white);
-  color: var(--main-color-green);
-  padding: 10px 20px;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
   margin: 1em 0 5em 2em;
   font-size: 1em;
 }
 
 .add-btn a {
-  text-decoration: none;
-  color: var(--main-color-green);
+  color: black;
 }
-
 /********** Queue View **********/
 .job-queue-container {
   margin: 2em;

--- a/templates/job_queue.html
+++ b/templates/job_queue.html
@@ -1,38 +1,38 @@
-{% extends "layout.html" %}
-{% block content %}
+{% extends "layout.html" %} {% block content %}
 <div class="job-queue-container">
-    <h2>Job Queue Log</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Job ID</th>
-                <th>Order ID</th>
-                <th>Job Name</th>
-                <th>Job Status</th>
-                <th>Status Message</th>
-                <th>Assigned Printer</th>
-                <th>Nozzle Size</th>
-                <th>Filament</th>
-                <th>Last Updated</th>
-                <th>Received</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for job in data.jobs %}
-            <tr>
-                <td>{{ job.job_ID }}</td>
-                <td>{{ job.order_ID }}</td>
-                <td>{{ job.job_name }}</td>
-                <td data-status="{{ job.job_status }}">{{ job.job_status }}</td>
-                <td>{{ job.status_message }}</td>
-                <td>{{ job.printer_assignment }}</td>
-                <td>{{ job.nozzle_size_needed }}</td>
-                <td>{{ job.filament }}</td>
-                <td>{{ job.last_updated }}</td>
-                <td>{{ job.received }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+  <h2>Job Queue Log</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Job ID</th>
+        <th>Order ID</th>
+        <th>Job Name</th>
+        <th>Job Status</th>
+        <th>Status Message</th>
+        <th>Assigned Printer</th>
+        <th>Nozzle Size</th>
+        <th>Filament</th>
+        <th>Last Updated</th>
+        <th>Received</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for job in data.jobs %}
+      <tr>
+        <td>{{ job.job_ID }}</td>
+        <td>{{ job.order_ID }}</td>
+        <td>{{ job.job_name }}</td>
+        <td data-status="{{ job.job_status }}">{{ job.job_status }}</td>
+        <td>{{ job.status_message }}</td>
+        <td>{{ job.printer_assignment }}</td>
+        <td>{{ job.nozzle_size_needed }}</td>
+        <td>{{ job.filament }}</td>
+        <td>{{ job.last_updated }}</td>
+        <td>{{ job.received }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <button class="primary-btn custom-btn"><a>Clear Complete</a></button>
 </div>
 {% endblock %}

--- a/templates/printer_page.html
+++ b/templates/printer_page.html
@@ -10,10 +10,13 @@
         <p>Filament Color: {{ printer.filamentColor }}</p>
         <p>Nozzle Size: {{ printer.nozzleDiameter }}</p>
         <p>Nozzle Diameter: {{ printer.nozzleDiameter }}</p>
-        <button class="set-btn">
+        <button class="primary-btn custom-btn">
           <a href="{{ url_for('configure') }}?printerid={{ printer.id }}"
             >Printer Settings</a
           >
+        </button>
+        <button class="secondary-btn">
+          <a href="">Change filament</a>
         </button>
       </li>
       {% endfor %}
@@ -44,9 +47,15 @@
         {% endfor %}
       </tbody>
     </table>
+    <button class="primary-btn custom-btn">
+      <a href="">Add Filament</a>
+    </button>
+    <button class="danger-btn">
+      <a href="">Remove Filament</a>
+    </button>
   </div>
 </div>
-<button class="add-btn">
+<button class="primary-btn add-btn">
   <a href="{{ url_for('add') }}">+ Add Printer</a>
 </button>
 {% endblock %}


### PR DESCRIPTION
### Code changes I made 
* Added a universal set of buttons, similar to Bootstrap so it's easier to create buttons 
* Adjusted their margin and padding 
* Added the missing buttons on the printer page and queue view 

![image](https://github.com/PhatCash/Capstone-3D/assets/100458150/0c1f87f0-263b-47c8-b73e-951331c2d167)

### Why I made these changes 
* It was a tedious experience trying to match existing padding and margins
* Made it easier to add new buttons 
* Consistent style across the web pages 

### Feedback I am looking for
* Is this a good style for the buttons? 
* Is there anything that needs improvement? 

**Note**: We need to refine the format of the settings for specific printers like changing it to a form-like document. Also, instead of having buttons for 'reprints', I think it would be easier to have a button that functions like the 'clear complete' for job queues 